### PR TITLE
fix: Exporting namespace

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -782,3 +782,5 @@ declare namespace NVD {
         }
     }
 }
+
+export = NVD;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thefaultvault/tfv-nvd-types",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "National Vulnerability Database typescript definitions for data feeds.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Needed to export the namespace so consuming modules can use it.