### PR TITLE
fix: Export the namespace directly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 /**
  * National Vulnerability Database Schema.
  */
-declare namespace NVD {
+export namespace NVD {
     /**
      * Common types across NVD objects.
      */
@@ -782,5 +782,3 @@ declare namespace NVD {
         }
     }
 }
-
-export = NVD;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thefaultvault/tfv-nvd-types",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "National Vulnerability Database typescript definitions for data feeds.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Exporting the namespace directly instead of setting the export equal to it.