### PR TITLE
fix: Export all namespaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ export namespace NVD {
     /**
      * Common types across NVD objects.
      */
-    namespace Common {
+    export namespace Common {
         /**
          * Description of some value (used on multiple objects).
          *
@@ -33,7 +33,7 @@ export namespace NVD {
     /**
      * Common Vulnerability Enumerations.
      */
-    namespace CVE {
+    export namespace CVE {
         /**
          * Top most container of the NVD CVE json feed.
          * Contains some meta about the feed as well as
@@ -669,7 +669,7 @@ export namespace NVD {
     /**
      * Common Product Enumerations.
      */
-    namespace CPE {
+    export namespace CPE {
         /**
          * Contains information for a cpe reference.
          *

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thefaultvault/tfv-nvd-types",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "National Vulnerability Database typescript definitions for data feeds.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Export all the namespaces not just the top level NVD namespace. Allows for a better type experience.